### PR TITLE
correcting edge case with precision validator not working properly for negative values

### DIFF
--- a/Valigator.Core/ValueValidators/PrecisionValidator.cs
+++ b/Valigator.Core/ValueValidators/PrecisionValidator.cs
@@ -50,7 +50,7 @@ namespace Valigator.Core.ValueValidators
 		}
 
 		private int GetPrecision(decimal decimalValue)
-			=> Math.Max((decimalValue - Math.Truncate(decimalValue)).ToString().Length - 2, 0);
+			=> Math.Max(Math.Abs((decimalValue - Math.Truncate(decimalValue))).ToString().Length - 2, 0);
 
 		ValidationError IValueValidator<decimal>.GetError(decimal value, bool inverted)
 			=> new ValidationError(nameof(PrecisionValidator), (this as IValueValidator<decimal>).GetDescriptor());

--- a/Valigator.Tests/ValidatorTests/PrecisionValidatorTests.cs
+++ b/Valigator.Tests/ValidatorTests/PrecisionValidatorTests.cs
@@ -26,6 +26,13 @@ namespace Valigator.Tests.ValidatorTests
 			=> Assert.Throws<ArgumentException>(() => new PrecisionValidator(10, 5));
 
 		[Fact]
+		public void NegativeNumberWithTwoDecimalPlaces()
+			=> new PrecisionValidator(2, 2)
+				.IsValid(-0.01m)
+				.Should()
+				.BeTrue();
+
+		[Fact]
 		public void MinimumOnlyBelowMinimum()
 			=> new PrecisionValidator(2, null)
 				.IsValid(0.0m)


### PR DESCRIPTION
- Making sure to get the absolute value of the decimal information in order to properly calculate the length using string length calculation.
- Added test to cover the edge case.