### PR TITLE
fix exception when non-data properties present

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Authors>Johannes Moersch</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright © 2020 Johannes Moersch</Copyright>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
 		<Product>Valigator</Product>
   </PropertyGroup>
 

--- a/Valigator.AspNetCore3.IntegrationTests/IntegrationTests.cs
+++ b/Valigator.AspNetCore3.IntegrationTests/IntegrationTests.cs
@@ -84,7 +84,20 @@ namespace Valigator.AspNetCore3.IntegrationTests
 				.IsSuccess()
 				.AssertJsonBody(str =>
 				{
-					str.Should().Be("{\"TheOutputOfThePost\":[{\"TheIdentifier\":\"61f45cfd-6389-4380-a803-c23881e982af\"}]}");
+					str.Should().Be("{\"TheOutputOfThePost\":[{\"TheIdentifier\":\"61f45cfd-6389-4380-a803-c23881e982af\"}],\"SecondValue\":1}");
+				});
+
+		[Fact]
+		public Task ObjectWithNonDataPropertyTest()
+			=> CreateClient()
+				.BuildTest()
+				.Post("test/nonDataPropertyObject")
+				.WithJsonBody($"{{ \"{nameof(BodyClass.IdentifierCollection)}\": [ {{\"{nameof(InnerClass.TheIdentifier)}\" : \"61f45cfd-6389-4380-a803-c23881e982af\"}} ] }}")
+				.Send()
+				.IsSuccess()
+				.AssertJsonBody(str =>
+				{
+					str.Should().Be("{\"IdentifierCollection\":[{\"TheIdentifier\":\"61f45cfd-6389-4380-a803-c23881e982af\"}],\"SecondValue\":1}");
 				});
 	}
 }

--- a/Valigator.Core/Core/Model.cs
+++ b/Valigator.Core/Core/Model.cs
@@ -121,11 +121,11 @@ namespace Valigator.Core
 		private static (PropertyInfo[] dataProperties, MemberInfo[] validateContentsMembers) FilterToDataPropertiesAndValidateContentsMembers(PropertyInfo[] properties, FieldInfo[] fields)
 		{
 			var dataProperties = properties
-				.Where(p => IsValigatorDataType(p.PropertyType))
+				.Where(p => p.PropertyType.IsValigatorDataType())
 				.ToArray();
 
 			var validateContentsProperties = properties
-				.Where(p => !IsValigatorDataType(p.PropertyType))
+				.Where(p => !p.PropertyType.IsValigatorDataType())
 				.Where(p => p.GetCustomAttribute<ValidateContentsAttribute>() != null)
 				.ToArray();
 
@@ -240,9 +240,6 @@ namespace Valigator.Core
 				currentType = currentType.BaseType;
 			}
 		}
-
-		private static bool IsValigatorDataType(Type type)
-			=> type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Data<>);
 
 		private static bool IsExplicitInterfaceImplementation(PropertyInfo prop)
 			=> prop.Name.Contains(".");

--- a/Valigator.Core/Extensions/TypeExtensions.cs
+++ b/Valigator.Core/Extensions/TypeExtensions.cs
@@ -1,0 +1,11 @@
+﻿// NOTE: GENERATED FILE //
+using System;
+
+namespace Valigator
+{
+	public static class TypeExtensions
+	{
+		public static bool IsValigatorDataType(this Type type)
+			=> type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Data<>);
+	}
+}

--- a/Valigator.Core/Valigator.Core.csproj
+++ b/Valigator.Core/Valigator.Core.csproj
@@ -13,8 +13,4 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Extensions\" />
-  </ItemGroup>
-
 </Project>

--- a/Valigator.Newtonsoft.Json/ValigatorJsonPropertyHandler.cs
+++ b/Valigator.Newtonsoft.Json/ValigatorJsonPropertyHandler.cs
@@ -17,9 +17,7 @@ namespace Valigator.Newtonsoft.Json
 
 		public static ValigatorJsonPropertyHandler<TObject> Create(PropertyInfo property)
 		{
-			var propertyHandlerType = property.PropertyType.IsValigatorDataType() ? typeof(ValigatorJsonPropertyHandler<,>) : typeof(NonValigatorDataJsonPropertyHandler<,>);
-
-			var propertyType = property.PropertyType.IsValigatorDataType() ? property.PropertyType.GetGenericArguments()[0] : property.PropertyType;
+			var (propertyHandlerType, propertyType) = GetPropertyTypeAndHandlerType(property);
 
 			var handlerType = propertyHandlerType.MakeGenericType(typeof(TObject), propertyType);
 
@@ -27,6 +25,9 @@ namespace Valigator.Newtonsoft.Json
 
 			return (ValigatorJsonPropertyHandler<TObject>)createMethod.Invoke(null, new[] { property });
 		}
+
+		private static (Type HandlerType, Type PropertyType) GetPropertyTypeAndHandlerType(PropertyInfo property)
+			=> property.PropertyType.IsValigatorDataType() ? (typeof(ValigatorJsonPropertyHandler<,>), property.PropertyType.GetGenericArguments()[0]) : (typeof(NonValigatorDataJsonPropertyHandler<,>), property.PropertyType);
 
 		internal static Func<TObject, TValue> CreateGetter<TValue>(PropertyInfo property)
 		{

--- a/Valigator.Newtonsoft.Json/ValigatorJsonPropertyHandler.cs
+++ b/Valigator.Newtonsoft.Json/ValigatorJsonPropertyHandler.cs
@@ -17,11 +17,83 @@ namespace Valigator.Newtonsoft.Json
 
 		public static ValigatorJsonPropertyHandler<TObject> Create(PropertyInfo property)
 		{
-			var handlerType = typeof(ValigatorJsonPropertyHandler<,>).MakeGenericType(typeof(TObject), property.PropertyType.GetGenericArguments()[0]);
+			var propertyHandlerType = property.PropertyType.IsValigatorDataType() ? typeof(ValigatorJsonPropertyHandler<,>) : typeof(NonValigatorDataJsonPropertyHandler<,>);
+
+			var propertyType = property.PropertyType.IsValigatorDataType() ? property.PropertyType.GetGenericArguments()[0] : property.PropertyType;
+
+			var handlerType = propertyHandlerType.MakeGenericType(typeof(TObject), propertyType);
 
 			var createMethod = handlerType.GetMethod(nameof(ValigatorJsonPropertyHandler<TObject, bool>.Create), BindingFlags.Public | BindingFlags.Static, Type.DefaultBinder, new[] { typeof(PropertyInfo) }, null);
 
 			return (ValigatorJsonPropertyHandler<TObject>)createMethod.Invoke(null, new[] { property });
+		}
+
+		internal static Func<TObject, TValue> CreateGetter<TValue>(PropertyInfo property)
+		{
+			var objParameter = Expression.Parameter(typeof(TObject), "obj");
+			var propertyParameter = Expression.Constant(property);
+
+			var getValueMethod = property.GetType().GetMethod(nameof(PropertyInfo.GetValue), new[] { typeof(object) });
+			var getterExpression = Expression.Convert(Expression.Call(propertyParameter, getValueMethod, objParameter), property.PropertyType);
+			var getter = property.CanRead ? Expression.Lambda<Func<TObject, TValue>>(getterExpression, objParameter).Compile() : null;
+
+			return getter;
+		}
+
+		internal static Action<TObject, TValue> CreateSetter<TValue>(PropertyInfo property)
+		{
+			var objParameter = Expression.Parameter(typeof(TObject), "obj");
+			var propertyParameter = Expression.Constant(property);
+
+			var valueParameter = Expression.Parameter(typeof(TValue), "value");
+			var setValueMethod = property.GetType().GetMethod(nameof(PropertyInfo.SetValue), new[] { typeof(object), typeof(object) });
+			var setProperty = Expression.Call(propertyParameter, setValueMethod, objParameter, Expression.Convert(valueParameter, typeof(object)));
+			var setter = property.CanWrite ? Expression.Lambda<Action<TObject, TValue>>(setProperty, objParameter, valueParameter).Compile() : null;
+
+			return setter;
+		}
+	}
+
+	internal class NonValigatorDataJsonPropertyHandler<TObject, TValue> : ValigatorJsonPropertyHandler<TObject>
+	{
+		private readonly Func<TObject, TValue> _getValue;
+		private readonly Action<TObject, TValue> _setValue;
+
+		public override bool CanRead => _getValue != null;
+		public override bool CanWrite => _setValue != null;
+
+		public NonValigatorDataJsonPropertyHandler(Func<TObject, TValue> getValue, Action<TObject, TValue> setValue)
+		{
+			_getValue = getValue;
+			_setValue = setValue;
+		}
+
+		public override void ReadProperty(JsonReader reader, JsonSerializer serializer, TObject obj)
+		{
+			if (_setValue != null)
+				_setValue(obj, serializer.Deserialize<TValue>(reader));
+			else
+				throw new NotSupportedException();
+		}
+
+		public override void WriteProperty(JsonWriter writer, JsonSerializer serializer, TObject obj)
+		{
+			if (_getValue != null)
+				serializer.Serialize(writer, _getValue(obj), typeof(TValue));
+			else
+				throw new NotSupportedException();
+		}
+
+		public new static NonValigatorDataJsonPropertyHandler<TObject, TValue> Create(PropertyInfo property)
+		{
+			if (property.GetCustomAttribute<JsonIgnoreAttribute>() != null)
+				return new NonValigatorDataJsonPropertyHandler<TObject, TValue>(null, null);
+
+
+			var getter = CreateGetter<TValue>(property);
+			var setter = CreateSetter<TValue>(property);
+
+			return new NonValigatorDataJsonPropertyHandler<TObject, TValue>(getter, setter);
 		}
 	}
 
@@ -60,18 +132,8 @@ namespace Valigator.Newtonsoft.Json
 			if (property.GetCustomAttribute<JsonIgnoreAttribute>() != null)
 				return new ValigatorJsonPropertyHandler<TObject, TDataValue>(null, null);
 
-			var objParameter = Expression.Parameter(typeof(TObject), "obj");
-
-			var propertyParameter = Expression.Constant(property);
-			var getValueMethod = property.GetType().GetMethod(nameof(PropertyInfo.GetValue), new[] { typeof(object) });
-			var propertyExpression = Expression.Convert(Expression.Call(propertyParameter, getValueMethod, objParameter), property.PropertyType);
-
-			var valueParameter = Expression.Parameter(typeof(Data<TDataValue>), "value");
-			var setValueMethod = property.GetType().GetMethod(nameof(PropertyInfo.SetValue), new[] { typeof(object), typeof(object) });
-			var setProperty = Expression.Call(propertyParameter, setValueMethod, objParameter, Expression.Convert(valueParameter, typeof(object)));
-
-			var getter = property.CanRead ? Expression.Lambda<Func<TObject, Data<TDataValue>>>(propertyExpression, objParameter).Compile() : null;
-			var setter = property.CanWrite ? Expression.Lambda<Action<TObject, Data<TDataValue>>>(setProperty, objParameter, valueParameter).Compile() : null;
+			var getter = CreateGetter<Data<TDataValue>>(property);
+			var setter = CreateSetter<Data<TDataValue>>(property);
 
 			return new ValigatorJsonPropertyHandler<TObject, TDataValue>(getter, setter);
 		}

--- a/Valigator.TestApi.Core31/Controllers/TestController.cs
+++ b/Valigator.TestApi.Core31/Controllers/TestController.cs
@@ -30,7 +30,7 @@ namespace Valigator.TestApi.Controllers
 
 		[HttpPost("nonDataPropertyObject")]
 		public JsonResult PostWithNonDataPropertyObject([FromBody] GuidBodyClass bodyValue)
-		=> new JsonResult(new NonDataPropertyModel(bodyValue.IdentifierCollection.Value));
+			=> new JsonResult(new NonDataPropertyModel(bodyValue.IdentifierCollection.Value));
 	}
 
 	[ValigatorModel]

--- a/Valigator.TestApi.Core31/Controllers/TestController.cs
+++ b/Valigator.TestApi.Core31/Controllers/TestController.cs
@@ -26,7 +26,24 @@ namespace Valigator.TestApi.Controllers
 
 		[HttpPost("anonymousObjectOutput")]
 		public JsonResult PostReturnsAnonymousObject([FromBody] GuidBodyClass bodyValue)
-			=> new JsonResult(new { TheOutputOfThePost = bodyValue.IdentifierCollection }.ToValigatorModel());
+			=> new JsonResult(new { TheOutputOfThePost = bodyValue.IdentifierCollection, SecondValue = 1 }.ToValigatorModel());
+
+		[HttpPost("nonDataPropertyObject")]
+		public JsonResult PostWithNonDataPropertyObject([FromBody] GuidBodyClass bodyValue)
+		=> new JsonResult(new NonDataPropertyModel(bodyValue.IdentifierCollection.Value));
+	}
+
+	[ValigatorModel]
+	public class NonDataPropertyModel
+	{
+		public Data<GuidInnerClass[]> IdentifierCollection { get; set; } = Data.Collection<GuidInnerClass>().Required().ItemCount(1);
+
+		public NonDataPropertyModel(GuidInnerClass[] identifierCollection)
+		{
+			IdentifierCollection = IdentifierCollection.WithValue(identifierCollection);
+		}
+
+		public int SecondValue { get; set; } = 1;
 	}
 
 	[ValigatorModel]

--- a/Valigator.TestApi.Core31/Startup.cs
+++ b/Valigator.TestApi.Core31/Startup.cs
@@ -25,6 +25,7 @@ namespace Valigator.TestApi
 		// This method gets called by the runtime. Use this method to add services to the container.
 		public void ConfigureServices(IServiceCollection services)
 		{
+			
 			services
 				.AddSingleton<IObjectModelValidator, NullObjectModelValidator>() //Disables ASP.NET Core validation because it skips over the ValigatorFilter and, as a result, the AddValigator Funcs will not be called.
 				.AddControllers()

--- a/Valigator.Text.Json/ValigatorConverter.cs
+++ b/Valigator.Text.Json/ValigatorConverter.cs
@@ -82,7 +82,7 @@ namespace Valigator.Text.Json
 		public override void Write(Utf8JsonWriter writer, TObject value, JsonSerializerOptions options)
 		{
 			writer.WriteStartObject();
-
+			
 			foreach (var handler in PropertyHandlers)
 			{
 				writer.WritePropertyName(handler.Key);

--- a/Valigator.Text.Json/ValigatorJsonPropertyHandler.cs
+++ b/Valigator.Text.Json/ValigatorJsonPropertyHandler.cs
@@ -18,9 +18,7 @@ namespace Valigator.Text.Json
 
 		public static ValigatorJsonPropertyHandler<TObject> Create(PropertyInfo property)
 		{
-			var propertyHandlerType = property.PropertyType.IsValigatorDataType() ? typeof(ValigatorJsonPropertyHandler<,>) : typeof(NonValigatorDataJsonPropertyHandler<,>);
-
-			var propertyType = property.PropertyType.IsValigatorDataType() ? property.PropertyType.GetGenericArguments()[0] : property.PropertyType;
+			var (propertyHandlerType, propertyType) = GetPropertyTypeAndHandlerType(property);
 
 			var handlerType = propertyHandlerType.MakeGenericType(typeof(TObject), propertyType);
 
@@ -28,6 +26,9 @@ namespace Valigator.Text.Json
 
 			return (ValigatorJsonPropertyHandler<TObject>)createMethod.Invoke(null, new[] { property });
 		}
+
+		private static (Type HandlerType, Type PropertyType) GetPropertyTypeAndHandlerType(PropertyInfo property)
+			=> property.PropertyType.IsValigatorDataType() ? (typeof(ValigatorJsonPropertyHandler<,>), property.PropertyType.GetGenericArguments()[0]) : (typeof(NonValigatorDataJsonPropertyHandler<,>), property.PropertyType);
 
 		internal static Func<TObject, TValue> CreateGetter<TValue>(PropertyInfo property)
 		{

--- a/Valigator.Text.Json/ValigatorJsonPropertyHandler.cs
+++ b/Valigator.Text.Json/ValigatorJsonPropertyHandler.cs
@@ -18,11 +18,83 @@ namespace Valigator.Text.Json
 
 		public static ValigatorJsonPropertyHandler<TObject> Create(PropertyInfo property)
 		{
-			var handlerType = typeof(ValigatorJsonPropertyHandler<,>).MakeGenericType(typeof(TObject), property.PropertyType.GetGenericArguments()[0]);
+			var propertyHandlerType = property.PropertyType.IsValigatorDataType() ? typeof(ValigatorJsonPropertyHandler<,>) : typeof(NonValigatorDataJsonPropertyHandler<,>);
+
+			var propertyType = property.PropertyType.IsValigatorDataType() ? property.PropertyType.GetGenericArguments()[0] : property.PropertyType;
+
+			var handlerType = propertyHandlerType.MakeGenericType(typeof(TObject), propertyType);
 
 			var createMethod = handlerType.GetMethod(nameof(ValigatorJsonPropertyHandler<TObject, bool>.Create), BindingFlags.Public | BindingFlags.Static, Type.DefaultBinder, new[] { typeof(PropertyInfo) }, null);
 
 			return (ValigatorJsonPropertyHandler<TObject>)createMethod.Invoke(null, new[] { property });
+		}
+
+		internal static Func<TObject, TValue> CreateGetter<TValue>(PropertyInfo property)
+		{
+			var objParameter = Expression.Parameter(typeof(TObject), "obj");
+			var propertyParameter = Expression.Constant(property);
+
+			var getValueMethod = property.GetType().GetMethod(nameof(PropertyInfo.GetValue), new[] { typeof(object) });
+			var getterExpression = Expression.Convert(Expression.Call(propertyParameter, getValueMethod, objParameter), property.PropertyType);
+			var getter = property.CanRead ? Expression.Lambda<Func<TObject, TValue>>(getterExpression, objParameter).Compile() : null;
+
+			return getter;
+		}
+
+		internal static Action<TObject, TValue> CreateSetter<TValue>(PropertyInfo property)
+		{
+			var objParameter = Expression.Parameter(typeof(TObject), "obj");
+			var propertyParameter = Expression.Constant(property);
+
+			var valueParameter = Expression.Parameter(typeof(TValue), "value");
+			var setValueMethod = property.GetType().GetMethod(nameof(PropertyInfo.SetValue), new[] { typeof(object), typeof(object) });
+			var setProperty = Expression.Call(propertyParameter, setValueMethod, objParameter, Expression.Convert(valueParameter, typeof(object)));
+			var setter = property.CanWrite ? Expression.Lambda<Action<TObject, TValue>>(setProperty, objParameter, valueParameter).Compile() : null;
+
+			return setter;
+		}
+	}
+
+	internal class NonValigatorDataJsonPropertyHandler<TObject, TValue> : ValigatorJsonPropertyHandler<TObject>
+	{
+		private readonly Func<TObject, TValue> _getValue;
+		private readonly Action<TObject, TValue> _setValue;
+
+		public override bool CanRead => _getValue != null;
+		public override bool CanWrite => _setValue != null;
+
+		public NonValigatorDataJsonPropertyHandler(Func<TObject, TValue> getValue, Action<TObject, TValue> setValue)
+		{
+			_getValue = getValue;
+			_setValue = setValue;
+		}
+
+		public override void ReadProperty(ref Utf8JsonReader reader, JsonSerializerOptions options, TObject obj)
+		{
+			if (_setValue != null)
+				_setValue(obj, JsonSerializer.Deserialize<TValue>(ref reader, options));
+			else
+				throw new NotSupportedException();
+		}
+
+		public override void WriteProperty(Utf8JsonWriter writer, JsonSerializerOptions options, TObject obj)
+		{
+			if (_getValue != null)
+				JsonSerializer.Serialize(writer, _getValue(obj), options);
+			else
+				throw new NotSupportedException();
+		}
+
+		public new static NonValigatorDataJsonPropertyHandler<TObject, TValue> Create(PropertyInfo property)
+		{
+			if (property.GetCustomAttribute<JsonIgnoreAttribute>() != null)
+				return new NonValigatorDataJsonPropertyHandler<TObject, TValue>(null, null);
+
+
+			var getter = CreateGetter<TValue>(property);
+			var setter = CreateSetter<TValue>(property);
+
+			return new NonValigatorDataJsonPropertyHandler<TObject, TValue>(getter, setter);
 		}
 	}
 
@@ -61,18 +133,8 @@ namespace Valigator.Text.Json
 			if (property.GetCustomAttribute<JsonIgnoreAttribute>() != null)
 				return new ValigatorJsonPropertyHandler<TObject, TDataValue>(null, null);
 
-			var objParameter = Expression.Parameter(typeof(TObject), "obj");
-
-			var propertyParameter = Expression.Constant(property);
-			var getValueMethod = property.GetType().GetMethod(nameof(PropertyInfo.GetValue), new[] { typeof(object) });
-			var propertyExpression = Expression.Convert(Expression.Call(propertyParameter, getValueMethod, objParameter), property.PropertyType);
-
-			var valueParameter = Expression.Parameter(typeof(Data<TDataValue>), "value");
-			var setValueMethod = property.GetType().GetMethod(nameof(PropertyInfo.SetValue), new[] { typeof(object), typeof(object) });
-			var setProperty = Expression.Call(propertyParameter, setValueMethod, objParameter, Expression.Convert(valueParameter, typeof(object)));
-
-			var getter = property.CanRead ? Expression.Lambda<Func<TObject, Data<TDataValue>>>(propertyExpression, objParameter).Compile() : null;
-			var setter = property.CanWrite ? Expression.Lambda<Action<TObject, Data<TDataValue>>>(setProperty, objParameter, valueParameter).Compile() : null;
+			var getter = CreateGetter<Data<TDataValue>>(property);
+			var setter = CreateSetter<Data<TDataValue>>(property);
 
 			return new ValigatorJsonPropertyHandler<TObject, TDataValue>(getter, setter);
 		}

--- a/Valigator.sln
+++ b/Valigator.sln
@@ -35,6 +35,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Valigator.Tests.Common", "V
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{FA1E881C-D1A5-4595-B52A-2113A91B2EF1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7EBB667E-7531-4D69-A828-B326690267B6}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
An exception was thrown when a ValigatorModel (either ValigatorModel or ValigatorModelAttribute) had properties that were not of type `Data<>`.

The exception is an index out of range because it was trying to the generic on a property that isn't a `Data<>`. This PR fixes that by defining a separate code path at the point of serialization/deserialization for those properties that are not `Data<>`