### PR TITLE
Override Valigator.Data Equals method & == operator to work with record types

### DIFF
--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -124,11 +124,10 @@ namespace Valigator
 			=> obj is Data<TValue> data
 		 && _dataContainer.DataDescriptor.Equals(data.DataDescriptor)
 					&& (_value.Equals(data._value)
-						|| (IsEnumerable<TValue>() && IsSequenceEqual(_value as IEnumerable, data._value as IEnumerable)));
+						|| (IsEnumerable<TValue>() && CheckEquality(_value as IEnumerable, data._value as IEnumerable)));
 
 		public static bool operator ==(Data<TValue> x, Data<TValue> y)
 			=> x.Equals(y);
-
 
 		private static bool IsSequenceEqual(IEnumerable a, IEnumerable b)
 		{
@@ -148,9 +147,8 @@ namespace Valigator
 			return e1Val == e2Val;
 		}
 
-
 		private static bool CheckEquality(object a, object b)
-		=> a is IEnumerable<object> aEnumerable && b is IEnumerable<object> bEnumerable && !(a is string) ?
+		=> a is IEnumerable aEnumerable && b is IEnumerable bEnumerable && !(a is string) ?
 			IsSequenceEqual(aEnumerable, bEnumerable) :
 			Equals(a, b);
 

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -123,7 +123,7 @@ namespace Valigator
 
 		public override bool Equals(object obj) 
 			=> obj is Data<TValue> data 
-				&& this == data;//if (obj is Data<TValue> data)//	return this == data;//else//	return false;
+				&& this == data;
 
 		public static bool operator ==(Data<TValue> x, Data<TValue> y) 
 			=> x.DataDescriptor.Equals(y.DataDescriptor)
@@ -138,7 +138,7 @@ namespace Valigator
 			int hashCode = 943777100;
 			var typeParameter = typeof(TValue);
 
-			if (typeParameter.IsArray || (typeParameter.IsGenericType && typeParameter.GetInterfaces().Any(t => t.GetGenericTypeDefinition() == typeof(IEnumerable<>))))
+			if (typeParameter.IsArray || typeParameter.IsEnum)
 			{
 				hashCode = hashCode * -1521134295 + (_value as IStructuralEquatable).GetHashCode((IEqualityComparer)typeof(EqualityComparer<>).MakeGenericType(typeParameter.GetElementType()).GetProperty(nameof(EqualityComparer<int>.Default)).GetValue(this));
 			}

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -137,7 +137,7 @@ namespace Valigator
 
 			while(firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
 			{
-				if (!(IsCollection(firstEnumerator.Current) && IsCollection(secondEnumerator.Current) ?
+				if (!(IsEnumerable(firstEnumerator.Current) && IsEnumerable(secondEnumerator.Current) ?
 					IsSequenceEqual(firstEnumerator.Current as ICollection, secondEnumerator.Current as ICollection)
 					: AreObjectsEqual(firstEnumerator.Current, secondEnumerator.Current)))
 					return false;
@@ -152,11 +152,11 @@ namespace Valigator
 			else
 				return false;
 		}
-		private static bool IsCollection(object a) 
-			=> a.GetType().GetInterface(nameof(ICollection)) != null;
 
 		private static bool IsEnumerable<T>(Data<T> a)
 			=> typeof(T).GetInterface(nameof(IEnumerable)) != null;
+		private static bool IsEnumerable(object a)
+			=> a.GetType().GetInterface(nameof(IEnumerable)) != null;
 
 		public static bool operator !=(Data<TValue> x, Data<TValue> y)
 			=> !x._value.Equals(y._value);

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using Functional;
 using Valigator.Core;
 using Valigator.Core.DataContainers;
@@ -117,5 +119,37 @@ namespace Valigator
 
 		public static implicit operator TValue(Data<TValue> data)
 			=> data.Value;
+
+		public override bool Equals(object obj) 
+			=> obj is Data<TValue> data 
+				&& this == data;//if (obj is Data<TValue> data)//	return this == data;//else//	return false;
+
+		public static bool operator ==(Data<TValue> x, Data<TValue> y) 
+			=> x.DataDescriptor.Equals(y.DataDescriptor)
+				&& (x._value.Equals(y._value) 
+					|| (typeof(TValue).IsArray && StructuralComparisons.StructuralEqualityComparer.Equals(x._value, y._value)));	
+
+		public static bool operator !=(Data<TValue> x, Data<TValue> y)
+			=> !x._value.Equals(y._value);
+
+		public override int GetHashCode()
+		{
+			int hashCode = 943777100;
+			var typeParameter = typeof(TValue);
+			if (typeParameter.IsArray || typeParameter.IsEnum)
+			{
+				foreach (var item in _value as IEnumerable)
+				{
+					hashCode = hashCode * -1521134295 + item.GetHashCode();
+				}
+			}
+			else
+				hashCode = hashCode * -1521134295 + EqualityComparer<TValue>.Default.GetHashCode(_value);
+
+			hashCode = hashCode * -1521134295 + State.GetHashCode();
+			hashCode = hashCode * -1521134295 + DataDescriptor.GetHashCode();
+			return hashCode;
+		}
+
 	}
 }

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -138,7 +138,7 @@ namespace Valigator
 			int hashCode = 943777100;
 			var typeParameter = typeof(TValue);
 
-			if (typeParameter.IsArray || typeParameter.IsEnum)
+			if (typeParameter.IsArray || (typeParameter.IsGenericType && typeParameter.GetInterfaces().Any(t => t.GetGenericTypeDefinition() == typeof(IEnumerable<>))))
 			{
 				hashCode = hashCode * -1521134295 + (_value as IStructuralEquatable).GetHashCode((IEqualityComparer)typeof(EqualityComparer<>).MakeGenericType(typeParameter.GetElementType()).GetProperty(nameof(EqualityComparer<int>.Default)).GetValue(this));
 			}

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -127,28 +127,22 @@ namespace Valigator
 		public static bool operator ==(Data<TValue> x, Data<TValue> y)
 			=> x.DataDescriptor.Equals(y.DataDescriptor)
 					&& (x._value.Equals(y._value)
-						|| (IsCollection(x) && IsCollection(y) && IsSequenceEqual(x._value as ICollection, y._value as ICollection)));
+						|| (IsEnumerable(x) && IsEnumerable(y) && IsSequenceEqual(x._value as IEnumerable, y._value as IEnumerable)));
 
 
-
-		private static bool IsSequenceEqual(ICollection a, ICollection b)
+		private static bool IsSequenceEqual(IEnumerable a, IEnumerable b)
 		{
-			if (a.Count == b.Count)
-			{
 				var firstEnumerator = a.GetEnumerator();
 				var secondEnumerator = b.GetEnumerator();
-				for (int i = 0; i < a.Count; i++)
-				{
-					firstEnumerator.MoveNext();
-					secondEnumerator.MoveNext();
-					if (!(IsCollection(firstEnumerator.Current) && IsCollection(secondEnumerator.Current) ?
-						IsSequenceEqual(firstEnumerator.Current as ICollection, secondEnumerator.Current as ICollection)
-						: AreObjectsEqual(firstEnumerator.Current, secondEnumerator.Current)))
-						return false;
-				}
-				return true;
+
+			while(firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
+			{
+				if (!(IsCollection(firstEnumerator.Current) && IsCollection(secondEnumerator.Current) ?
+					IsSequenceEqual(firstEnumerator.Current as ICollection, secondEnumerator.Current as ICollection)
+					: AreObjectsEqual(firstEnumerator.Current, secondEnumerator.Current)))
+					return false;
 			}
-			return false;		
+				return firstEnumerator.MoveNext() == secondEnumerator.MoveNext();	
 		}
 
 		private static bool AreObjectsEqual(object a, object b)
@@ -161,8 +155,8 @@ namespace Valigator
 		private static bool IsCollection(object a) 
 			=> a.GetType().GetInterface(nameof(ICollection)) != null;
 
-		private static bool IsCollection<T>(Data<T> a)
-			=> typeof(T).GetInterface(nameof(ICollection)) != null;
+		private static bool IsEnumerable<T>(Data<T> a)
+			=> typeof(T).GetInterface(nameof(IEnumerable)) != null;
 
 		public static bool operator !=(Data<TValue> x, Data<TValue> y)
 			=> !x._value.Equals(y._value);
@@ -170,9 +164,9 @@ namespace Valigator
 		public override int GetHashCode()
 		{
 			int hashCode = 943777100;
-			if (IsCollection(this))
+			if (IsEnumerable(this))
 			{
-				foreach (var item in _value as ICollection)
+				foreach (var item in _value as IEnumerable)
 				{
 					hashCode = hashCode * -1521134295 + item.GetHashCode();
 				}

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -138,7 +138,7 @@ namespace Valigator
 			while(firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
 			{
 				if (!(IsEnumerable(firstEnumerator.Current) && IsEnumerable(secondEnumerator.Current) ?
-					IsSequenceEqual(firstEnumerator.Current as ICollection, secondEnumerator.Current as ICollection)
+					IsSequenceEqual(firstEnumerator.Current as IEnumerable, secondEnumerator.Current as IEnumerable)
 					: AreObjectsEqual(firstEnumerator.Current, secondEnumerator.Current)))
 					return false;
 			}
@@ -155,6 +155,7 @@ namespace Valigator
 
 		private static bool IsEnumerable<T>(Data<T> a)
 			=> typeof(T).GetInterface(nameof(IEnumerable)) != null;
+
 		private static bool IsEnumerable(object a)
 			=> a.GetType().GetInterface(nameof(IEnumerable)) != null;
 

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -170,11 +170,9 @@ namespace Valigator
 		public override int GetHashCode()
 		{
 			int hashCode = 943777100;
-			var typeParameter = typeof(TValue);
-
-			if (typeParameter.IsArray || _value is IEnumerable)
+			if (IsCollection(this))
 			{
-				foreach (var item in _value as IEnumerable)
+				foreach (var item in _value as ICollection)
 				{
 					hashCode = hashCode * -1521134295 + item.GetHashCode();
 				}

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Functional;
 using Valigator.Core;
 using Valigator.Core.DataContainers;
@@ -136,12 +137,10 @@ namespace Valigator
 		{
 			int hashCode = 943777100;
 			var typeParameter = typeof(TValue);
-			if (typeParameter.IsArray || typeParameter.IsEnum)
+
+			if (typeParameter.IsArray || (typeParameter.IsGenericType && typeParameter.GetInterfaces().Any(t => t.GetGenericTypeDefinition() == typeof(IEnumerable<>))))
 			{
-				foreach (var item in _value as IEnumerable)
-				{
-					hashCode = hashCode * -1521134295 + item.GetHashCode();
-				}
+				hashCode = hashCode * -1521134295 + (_value as IStructuralEquatable).GetHashCode((IEqualityComparer)typeof(EqualityComparer<>).MakeGenericType(typeParameter.GetElementType()).GetProperty(nameof(EqualityComparer<int>.Default)).GetValue(this));
 			}
 			else
 				hashCode = hashCode * -1521134295 + EqualityComparer<TValue>.Default.GetHashCode(_value);

--- a/Valigator.Core/Data.cs
+++ b/Valigator.Core/Data.cs
@@ -127,7 +127,7 @@ namespace Valigator
 		public static bool operator ==(Data<TValue> x, Data<TValue> y)
 			=> x.DataDescriptor.Equals(y.DataDescriptor)
 					&& (x._value.Equals(y._value)
-						|| (IsEnumerable(x) && IsEnumerable(y) && IsSequenceEqual(x._value as IEnumerable, y._value as IEnumerable)));
+						|| (IsEnumerable<TValue>() && IsSequenceEqual(x._value as IEnumerable, y._value as IEnumerable)));
 
 
 		private static bool IsSequenceEqual(IEnumerable a, IEnumerable b)
@@ -144,7 +144,7 @@ namespace Valigator
 			}
 				return firstEnumerator.MoveNext() == secondEnumerator.MoveNext();	
 		}
-
+		
 		private static bool AreObjectsEqual(object a, object b)
 		{
 			if (a.GetType() == b.GetType())
@@ -153,7 +153,7 @@ namespace Valigator
 				return false;
 		}
 
-		private static bool IsEnumerable<T>(Data<T> a)
+		private static bool IsEnumerable<T>()
 			=> typeof(T).GetInterface(nameof(IEnumerable)) != null;
 
 		private static bool IsEnumerable(object a)
@@ -165,7 +165,7 @@ namespace Valigator
 		public override int GetHashCode()
 		{
 			int hashCode = 943777100;
-			if (IsEnumerable(this))
+			if (IsEnumerable<TValue>())
 			{
 				foreach (var item in _value as IEnumerable)
 				{

--- a/Valigator.Tests/DataEqualityTests.cs
+++ b/Valigator.Tests/DataEqualityTests.cs
@@ -135,6 +135,17 @@ namespace Valigator.Tests
 			item1.UniqueGuid.Equals(item2.UniqueGuid).Should().BeFalse();
 		}
 
+		[Fact]
+		public void IEnumerablesDifferentNumberOfElements()
+		{
+			var collection = TestIEnumerableRecord.CreateTestIEnumerableRecord(new ReadOnlyCollection<string>(new List<string>() { "123", "234", "456", "456" }));
+			var collection2 = TestIEnumerableRecord.CreateTestIEnumerableRecord(new ReadOnlyCollection<string>(new List<string>() { "123", "234", "456" }));
+			(collection == collection2).Should().BeFalse();
+			(collection.ReadOnlyCollection == collection2.ReadOnlyCollection).Should().BeFalse();
+			(collection != collection2).Should().BeTrue();
+			(collection.ReadOnlyCollection != collection2.ReadOnlyCollection).Should().BeTrue();
+		}
+
 
 
 		public record TestRecord

--- a/Valigator.Tests/DataEqualityTests.cs
+++ b/Valigator.Tests/DataEqualityTests.cs
@@ -13,7 +13,7 @@ namespace Valigator.Tests
 		{
 			var guid = Guid.NewGuid();
 			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
 			item1.Equals(item1).Should().BeTrue();
 			item1.ID.Equals(item1.ID).Should().BeTrue();
 			item1.UniqueGuid.Equals(item1.UniqueGuid).Should().BeTrue();
@@ -27,13 +27,12 @@ namespace Valigator.Tests
 			var guid = Guid.NewGuid();
 			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
 
-			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
-			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
+			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
 
 			item1.Equals(item2).Should().BeTrue();
 			(item1 == item2).Should().BeTrue();
 			item1.Should().Be(item2);
-
 		}
 
 		[Fact]
@@ -42,8 +41,8 @@ namespace Valigator.Tests
 			var guid = Guid.NewGuid();
 			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
 
-			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
-			var item2 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids);
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
+			var item2 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids, new string[] { "1", "2", "3" });
 
 			(item1.Equals(item2)).Should().BeFalse();
 			(item1 == item2).Should().BeFalse();
@@ -55,9 +54,21 @@ namespace Valigator.Tests
 			var guid = Guid.NewGuid();
 			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
 
-			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
 
 			item1.UniqueName.Equals(item1.UniqueNameWithDifferentDataDescriptors).Should().BeFalse();
+		}
+
+		[Fact]
+		public void CompareDataStringArrayEquality()
+		{
+			var guid = Guid.NewGuid();
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
+			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
+
+			item1.ArrayOfString.Equals(item2.ArrayOfString).Should().BeTrue();
 		}
 
 		[Fact]
@@ -66,8 +77,8 @@ namespace Valigator.Tests
 			var guid = Guid.NewGuid();
 			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
 
-			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
-			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
+			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
 
 			item1.ArrayOfUniqueGuid.GetHashCode().Equals(item2.ArrayOfUniqueGuid.GetHashCode()).Should().BeTrue();
 		}
@@ -78,8 +89,8 @@ namespace Valigator.Tests
 			var guid = Guid.NewGuid();
 			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
 
-			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
-			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
+			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids, new string[] { "1", "2", "3" });
 
 			item1.GetHashCode().Equals(item2.GetHashCode()).Should().BeTrue();
 		}
@@ -89,8 +100,8 @@ namespace Valigator.Tests
 		{
 			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
 
-			var item1 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids);
-			var item2 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids);
+			var item1 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids, new string[] { "1", "2", "3" });
+			var item2 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids, new string[] { "1", "2", "3" });
 
 			item1.UniqueGuid.Equals(item2.UniqueGuid).Should().BeFalse();
 		}
@@ -101,18 +112,19 @@ namespace Valigator.Tests
 		{
 
 
-			public static TestRecord CreateTestRecord(Guid liiGuid, Guid[] uniqueGuids)
+			public static TestRecord CreateTestRecord(Guid liiGuid, Guid[] uniqueGuids, string[] stringArray)
 			{
-				return new TestRecord(1, PrimitiveLikeTypeHelpers.CreateNew(liiGuid), "***", uniqueGuids.Select(guid => PrimitiveLikeTypeHelpers.CreateNew(guid)).ToArray());
+				return new TestRecord(1, PrimitiveLikeTypeHelpers.CreateNew(liiGuid), "***", uniqueGuids.Select(guid => PrimitiveLikeTypeHelpers.CreateNew(guid)).ToArray(), stringArray);
 			}
 
-			public TestRecord(int id, PrimitiveLikeType lineItemID, string taxName, PrimitiveLikeType[] uniquePrimitives)
+			public TestRecord(int id, PrimitiveLikeType lineItemID, string taxName, PrimitiveLikeType[] uniquePrimitives, string[] stringArray)
 			{
 				ID = ID.WithValue(id).Verify();
 				UniqueGuid = UniqueGuid.WithUncheckedValue(lineItemID).Verify();
 				UniqueName = UniqueName.WithValue(taxName).Verify();
 				UniqueNameWithDifferentDataDescriptors = UniqueNameWithDifferentDataDescriptors.WithValue(taxName).Verify();
 				ArrayOfUniqueGuid = ArrayOfUniqueGuid.WithValue(uniquePrimitives).Verify();
+				ArrayOfString = ArrayOfString.WithValue(stringArray).Verify();
 			}
 
 			public Data<int> ID { get; private set; } = Data.Required<int>();
@@ -124,6 +136,8 @@ namespace Valigator.Tests
 			public Data<string> UniqueNameWithDifferentDataDescriptors { get; private set; } = Data.Required<string>().Length(minimumLength: 3, maximumLength: 255);
 
 			public Data<PrimitiveLikeType[]> ArrayOfUniqueGuid = Data.Collection<PrimitiveLikeType>().Required().ItemCount(minimumItems: 1, maximumItems: 4);
+
+			public Data<string[]> ArrayOfString = Data.Collection<string>().Required().ItemCount(minimumItems: 1, maximumItems: 3);
 		}
 
 		public readonly struct PrimitiveLikeType : IEquatable<PrimitiveLikeType>

--- a/Valigator.Tests/DataEqualityTests.cs
+++ b/Valigator.Tests/DataEqualityTests.cs
@@ -61,17 +61,6 @@ namespace Valigator.Tests
 		}
 
 		[Fact]
-		public void CheckHashCode()
-		{
-			var guid = Guid.NewGuid();
-			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-
-			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
-
-			item1.ArrayOfUniqueGuid.GetHashCode();
-		}
-
-		[Fact]
 		public void CompareDataArrayHashCode()
 		{
 			var guid = Guid.NewGuid();
@@ -137,7 +126,7 @@ namespace Valigator.Tests
 			public Data<PrimitiveLikeType[]> ArrayOfUniqueGuid = Data.Collection<PrimitiveLikeType>().Required().ItemCount(minimumItems: 1, maximumItems: 4);
 		}
 
-		public readonly struct PrimitiveLikeType : IEquatable<PrimitiveLikeType> //, IComparable<PrimitiveLikeType>
+		public readonly struct PrimitiveLikeType : IEquatable<PrimitiveLikeType>
 		{
 			private readonly Option<Guid> _value;
 			internal readonly Guid Value => _value.Match(s => s, () => throw new ValueTypeNotInitializedException(typeof(PrimitiveLikeType)));

--- a/Valigator.Tests/DataEqualityTests.cs
+++ b/Valigator.Tests/DataEqualityTests.cs
@@ -1,0 +1,199 @@
+﻿using FluentAssertions;
+using Functional;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Valigator.Tests
+{
+	public class DataEqualityTests
+	{
+		[Fact]
+		public void RecordEqualsItself()
+		{
+			var guid = Guid.NewGuid();
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			item1.Equals(item1).Should().BeTrue();
+			item1.ID.Equals(item1.ID).Should().BeTrue();
+			item1.UniqueGuid.Equals(item1.UniqueGuid).Should().BeTrue();
+			item1.ArrayOfUniqueGuid.Equals(item1.ArrayOfUniqueGuid).Should().BeTrue();
+			item1.UniqueName.Equals(item1.UniqueName).Should().BeTrue();
+		}
+
+		[Fact]
+		public void RecordsEqual()
+		{
+			var guid = Guid.NewGuid();
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+
+			item1.Equals(item2).Should().BeTrue();
+			(item1 == item2).Should().BeTrue();
+			item1.Should().Be(item2);
+
+		}
+
+		[Fact]
+		public void RecordsDoNotEqual()
+		{
+			var guid = Guid.NewGuid();
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item2 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids);
+
+			(item1.Equals(item2)).Should().BeFalse();
+			(item1 == item2).Should().BeFalse();
+		}
+
+		[Fact]
+		public void RemoveDescriptors()
+		{
+			var guid = Guid.NewGuid();
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+
+			item1.UniqueName.Equals(item1.UniqueNameWithDifferentDataDescriptors).Should().BeFalse();
+		}
+
+		[Fact]
+		public void CheckHashCode()
+		{
+			var guid = Guid.NewGuid();
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+
+			item1.ArrayOfUniqueGuid.GetHashCode();
+		}
+
+		[Fact]
+		public void CompareDataArrayHashCode()
+		{
+			var guid = Guid.NewGuid();
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+
+			item1.ArrayOfUniqueGuid.GetHashCode().Equals(item2.ArrayOfUniqueGuid.GetHashCode()).Should().BeTrue();
+		}
+
+		[Fact]
+		public void CompareRecordHashCode()
+		{
+			var guid = Guid.NewGuid();
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+			var item1 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+			var item2 = TestRecord.CreateTestRecord(guid, uniqueGuids);
+
+			item1.GetHashCode().Equals(item2.GetHashCode()).Should().BeTrue();
+		}
+
+		[Fact]
+		public void CompareDifferentHashCode()
+		{
+			var uniqueGuids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+
+			var item1 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids);
+			var item2 = TestRecord.CreateTestRecord(Guid.NewGuid(), uniqueGuids);
+
+			item1.UniqueGuid.Equals(item2.UniqueGuid).Should().BeFalse();
+		}
+
+
+
+		public record TestRecord
+		{
+
+
+			public static TestRecord CreateTestRecord(Guid liiGuid, Guid[] uniqueGuids)
+			{
+				return new TestRecord(1, PrimitiveLikeTypeHelpers.CreateNew(liiGuid), "***", uniqueGuids.Select(guid => PrimitiveLikeTypeHelpers.CreateNew(guid)).ToArray());
+			}
+
+			public TestRecord(int id, PrimitiveLikeType lineItemID, string taxName, PrimitiveLikeType[] uniquePrimitives)
+			{
+				ID = ID.WithValue(id).Verify();
+				UniqueGuid = UniqueGuid.WithUncheckedValue(lineItemID).Verify();
+				UniqueName = UniqueName.WithValue(taxName).Verify();
+				UniqueNameWithDifferentDataDescriptors = UniqueNameWithDifferentDataDescriptors.WithValue(taxName).Verify();
+				ArrayOfUniqueGuid = ArrayOfUniqueGuid.WithValue(uniquePrimitives).Verify();
+			}
+
+			public Data<int> ID { get; private set; } = Data.Required<int>();
+
+			public Data<PrimitiveLikeType> UniqueGuid { get; private set; } = PrimitiveLikeType.Valigator.Required;
+
+			public Data<string> UniqueName { get; private set; } = Data.Required<string>().Length(minimumLength: 1, maximumLength: 255);
+
+			public Data<string> UniqueNameWithDifferentDataDescriptors { get; private set; } = Data.Required<string>().Length(minimumLength: 3, maximumLength: 255);
+
+			public Data<PrimitiveLikeType[]> ArrayOfUniqueGuid = Data.Collection<PrimitiveLikeType>().Required().ItemCount(minimumItems: 1, maximumItems: 4);
+		}
+
+		public readonly struct PrimitiveLikeType : IEquatable<PrimitiveLikeType> //, IComparable<PrimitiveLikeType>
+		{
+			private readonly Option<Guid> _value;
+			internal readonly Guid Value => _value.Match(s => s, () => throw new ValueTypeNotInitializedException(typeof(PrimitiveLikeType)));
+
+			internal PrimitiveLikeType(Guid value)
+				=> _value = Option.Some(value);
+
+			public override readonly bool Equals(object obj)
+				=> obj is PrimitiveLikeType productSku && Equals(productSku);
+
+			public override readonly int GetHashCode()
+				=> _value.GetHashCode();
+
+			public readonly bool Equals(PrimitiveLikeType other)
+				=> _value == other._value;
+
+			public static bool operator ==(PrimitiveLikeType identifier1, PrimitiveLikeType identifier2)
+				=> identifier1.Equals(identifier2);
+
+			public static bool operator !=(PrimitiveLikeType identifier1, PrimitiveLikeType identifier2)
+				=> !(identifier1 == identifier2);
+
+			public override string ToString()
+				=> $"{Value}";
+
+			public static class Valigator
+			{
+				private static readonly Data<Guid> _data = Data.Required<Guid>().NotEmpty();
+
+				public static Data<PrimitiveLikeType> Required { get; } 
+					= Data.Required<PrimitiveLikeType>().MappedFrom<Guid>(CreateLineItemIdentifier, _ => _data);
+
+				public static Data<Option<PrimitiveLikeType>> Optional { get; } = Data.Optional<PrimitiveLikeType>().MappedFrom<Guid>(CreateLineItemIdentifier, _ => _data);
+
+				public static Data<Option<PrimitiveLikeType[]>> OptionalCollection { get; }
+					= Data.Collection<PrimitiveLikeType>().Optional().MappedFrom<Guid>(CreateLineItemIdentifier, _ => _data);
+
+				public static Data<PrimitiveLikeType[]> RequiredCollection { get; }
+					= Data.Collection<PrimitiveLikeType>().Required().MappedFrom<Guid>(CreateLineItemIdentifier, _ => _data);
+
+				private static PrimitiveLikeType CreateLineItemIdentifier(Guid guid)
+					=> new(guid);
+			}
+
+		}
+		public class ValueTypeNotInitializedException : Exception
+		{
+			public ValueTypeNotInitializedException(Type type) : base($"Value type '{type.Name}' not initialized.") { }
+		}
+		private static class PrimitiveLikeTypeHelpers
+		{
+			public static PrimitiveLikeType CreateNew()
+				=> new(Guid.NewGuid());
+
+			public static PrimitiveLikeType CreateNew(Guid guid)
+				=> new(guid);
+		}
+	}
+}


### PR DESCRIPTION
Override Valigator.Data Equals method & == operator to work with record types.

Add Valigator.Data GetHashCode method.
Add Tests to validate Equals.