### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/Valigator.AspNetCore3.IntegrationTests/Valigator.AspNetCore3.IntegrationTests.csproj
+++ b/Valigator.AspNetCore3.IntegrationTests/Valigator.AspNetCore3.IntegrationTests.csproj
@@ -9,11 +9,11 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Functional.All" Version="1.18.0" />
-    <PackageReference Include="Interrogator.Http" Version="0.10.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Interrogator.Http" Version="0.11.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@JohannesMoersch@NathanMagnus, I found an issue in the Valigator.AspNetCore3.IntegrationTests.csproj:

Packages Interrogator.Http v0.10.0, Microsoft.AspNetCore.Mvc.Testing v3.1.0, Microsoft.NET.Test.Sdk v16.2.0 and xunit.runner.visualstudio v2.4.1 transitively introduce 139 dependencies into Valigator’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/Valigator.html)), while Interrogator.Http v0.11.0, Microsoft.AspNetCore.Mvc.Testing v3.1.3, Microsoft.NET.Test.Sdk v16.5.0 and xunit.runner.visualstudio v2.4.3 can only introduce 91 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/Valigator_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose